### PR TITLE
Bumping branch protection wait as heroku was faster than expected

### DIFF
--- a/src/api/webhook/repository.ts
+++ b/src/api/webhook/repository.ts
@@ -22,9 +22,9 @@ repository.post('/repository', async (req, res) => {
   const event = body as RepositoryWebhookPayload;
   if (event.action === 'created') {
     try {
-      // Give GitHub a 500ms a create the first commmit/branch
+      // Give GitHub a 1000ms a create the first commmit/branch
       // Without this, we'll make the request too quickly and the request will fail with  404
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await new Promise((resolve) => setTimeout(resolve, 1000));
       await github.repos.updateBranchProtection({
         branch: event.repository.default_branch,
         repo: event.repository.name,


### PR DESCRIPTION
## Description of Changes
<!-- Enter a description of what this PR does -->
Heroku gets the event significantly faster than local via ngrok, so I'm bumping the wait to prevent `404`s because the repo branch hasn't been created yet.

## Related Issues
<!-- List any related issues and make sure to include `Fixes` or `Closes` for issues this PR should close -->
